### PR TITLE
Install instruction when using Gradle

### DIFF
--- a/jabm/src/main/java/net/sourceforge/jabm/report/CSVReader.java
+++ b/jabm/src/main/java/net/sourceforge/jabm/report/CSVReader.java
@@ -30,20 +30,20 @@ public class CSVReader implements Serializable {
 	
 	transient BufferedReader in;
 
-	char seperator;
+  char separator;
 
 	Class[] types;
 
-	static final char DEFAULT_SEPERATOR = '\t';
+  static final char DEFAULT_SEPARATOR = '\t';
 
-	public CSVReader(InputStream in, Class[] types, char seperator) {
+  public CSVReader(InputStream in, Class[] types, char separator) {
 		this.in = new BufferedReader(new InputStreamReader(in));
-		this.seperator = seperator;
+    this.separator = separator;
 		this.types = types;
 	}
 
 	public CSVReader(InputStream in, Class[] types) {
-		this(in, types, DEFAULT_SEPERATOR);
+    this(in, types, DEFAULT_SEPARATOR);
 	}
 
 	public List nextRecord() throws IOException {
@@ -52,7 +52,7 @@ public class CSVReader implements Serializable {
 		if (line == null) {
 			return null;
 		}
-		StringTokenizer tokens = new StringTokenizer(line, seperator + "");
+    StringTokenizer tokens = new StringTokenizer(line, separator + "");
 		for (int i = 0; i < types.length; i++) {
 			String fieldStr = tokens.nextToken();
 			record.add(convert(fieldStr, types[i]));

--- a/jabm/src/main/java/net/sourceforge/jabm/report/CSVWriter.java
+++ b/jabm/src/main/java/net/sourceforge/jabm/report/CSVWriter.java
@@ -41,32 +41,32 @@ public class CSVWriter implements Serializable, DataWriter {
 
 	protected int currentColumn = 0;
 
-	protected char seperator = DEFAULT_SEPERATOR;
+  protected char separator = DEFAULT_SEPARATOR;
 
 	protected boolean append = true;
 
-	static final char DEFAULT_SEPERATOR = '\t';
+  static final char DEFAULT_SEPARATOR = '\t';
 
 	static Logger logger = Logger.getLogger(CSVWriter.class);
 
-	public CSVWriter(OutputStream out, int numColumns, char seperator) {
+  public CSVWriter(OutputStream out, int numColumns, char separator) {
 		this.out = new PrintStream(new BufferedOutputStream(out));
 		this.numColumns = numColumns;
-		this.seperator = seperator;
+    this.separator = separator;
 	}
 
-	public CSVWriter(OutputStream out, char seperator) {
+  public CSVWriter(OutputStream out, char separator) {
 		this.out = new PrintStream(new BufferedOutputStream(out));
 		this.autowrap = false;
-		this.seperator = seperator;
+    this.separator = separator;
 	}
 
 	public CSVWriter(OutputStream out, int numColumns) {
-		this(out, numColumns, DEFAULT_SEPERATOR);
+    this(out, numColumns, DEFAULT_SEPARATOR);
 	}
 
 	public CSVWriter(OutputStream out) {
-		this(out, DEFAULT_SEPERATOR);
+    this(out, DEFAULT_SEPARATOR);
 	}
 
 	public CSVWriter() {
@@ -196,22 +196,21 @@ public class CSVWriter implements Serializable, DataWriter {
 
 	public void setNumColumns(int numColumns) {
 		if (!autowrap)
-			new Error(
-			    "The number of columns should NOT be set when autowrap is disabled.");
+      new Error("The number of columns should NOT be set when autowrap is disabled.");
 		this.numColumns = numColumns;
 	}
 
 	protected void prepareColumn() {
 		if (!autowrap)
 			if (currentColumn > 0)
-				out.print(seperator);
+        out.print(separator);
 	}
 
 	protected void nextColumn() {
 		currentColumn++;
 		if (autowrap)
 			if (currentColumn < numColumns) {
-				out.print(seperator);
+        out.print(separator);
 			} else {
 				newLine();
 			}

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,28 @@ and then configure a dependency on the jabm artifact; for example:
 			<version>0.9.1</version>
 		</dependency>
 	</dependencies>
+
+
+### Installation using Gradle
+
+If you use gradle to build your project, you have to include the following snippets in your `build.gradle`:
+
+```
+dependencies {
+   implementation 'net.sourceforge.jabm:jabm:0.9.9'
+}
+```
+
+as well as specify the repository as:
+
+```
+repositories {
+    mavenCentral()
+    maven {
+       url = "http://jabm.sourceforge.net/mvn-repo/jabm"
+    }
+}
+```
 	
 ### Running the examples from the Eclipse IDE
 


### PR DESCRIPTION
Hey, 
I am using jabm for a project and use gradle to build it. If I only include
`compile 'net.sourceforge.jabm:jabm:0.9.9'` in my build.gradle, I run into a error because the dependency `infoNode:idw` of jabm cannot be found on mavenCentral or jcenter. I had to include the sourceforge repo to be able to install/use jabm.